### PR TITLE
[fix]修复在放大漫画后触底时左右滑动却触发翻页

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Thumbs.db
 
 /logs
 src/config.json
+CLAUDE.md

--- a/src/pages/photo/photo.ux
+++ b/src/pages/photo/photo.ux
@@ -19,6 +19,7 @@
 			scroll-y="true"
 			bounces="true"
 			@scrollbottom="onScrollBottom"
+			@scroll="onScroll"
 		>
 			<div @click="showButton" if="{{ images }}" class="padding"></div>
 			<div
@@ -244,7 +245,10 @@ export default {
 		downloadChapter: "",
 		chapterList: [],
 		pickerValues: [],
-		hasReachedBottom: false,
+		hasReachedBottom: 0,
+		prevScrollX: 0,
+		prevScrollY: 0,
+		waitingConfirm: false,
 	},
 
 	onShow() {
@@ -447,7 +451,10 @@ export default {
 				}
 				break;
 		}
-		this.hasReachedBottom = false;
+		this.hasReachedBottom = 0;
+		this.prevScrollX = 0;
+		this.prevScrollY = 0;
+		this.waitingConfirm = false;
 		this.$element("scrollId").scrollTo({
 			top: 0,
 			left: 0,
@@ -470,7 +477,10 @@ export default {
 				}
 				break;
 		}
-		this.hasReachedBottom = false;
+		this.hasReachedBottom = 0;
+		this.prevScrollX = 0;
+		this.prevScrollY = 0;
+		this.waitingConfirm = false;
 		this.$element("scrollId").scrollTo({
 			top: 0,
 			left: 0,
@@ -604,7 +614,10 @@ export default {
 		} else {
 			this.title = `${this.$t("photo.chapter")} ${this.chapter}`;
 		}
-		this.hasReachedBottom = false;
+		this.hasReachedBottom = 0;
+		this.prevScrollX = 0;
+		this.prevScrollY = 0;
+		this.waitingConfirm = false;
 		this.$element("scrollId").scrollTo({
 			top: 0,
 			left: 0,
@@ -652,17 +665,46 @@ export default {
 
 	onSliderChange(e) {
 		this.scale = e.progress;
+		this.prevScrollX = 0;
+		this.prevScrollY = 0;
 		this.$element("scrollId").scrollTo({
 			top: 0,
 			left: 0,
 		});
 	},
 
+	onScroll(e) {
+		const deltaX = Math.abs(e.scrollX - this.prevScrollX);
+		const deltaY = Math.abs(e.scrollY - this.prevScrollY);
+		this.prevScrollX = e.scrollX;
+		this.prevScrollY = e.scrollY;
+
+		if (this.scale > 0 && this.waitingConfirm) {
+			if (deltaX > deltaY && deltaX > 3) {
+				// 横向滑动，取消待确认状态，不翻页
+				this.waitingConfirm = false;
+				this.hasReachedBottom = 0;
+			} else if (deltaY > deltaX && deltaY > 10) {
+				// 明确的纵向向下滑动，确认翻页
+				this.waitingConfirm = false;
+				this.toPage("+");
+			}
+		}
+	},
+
 	onScrollBottom() {
-		if (!this.hasReachedBottom) {
-			this.hasReachedBottom = true;
+		if (this.scale > 0) {
+			// 放大状态：进入待确认，等后续滑动方向决定是否翻页
+			this.hasReachedBottom++;
+			if (this.hasReachedBottom >= 2) {
+				this.waitingConfirm = true;
+			}
 		} else {
-			this.toPage("+");
+			// 未放大：原有逻辑，第2次触底直接翻页
+			this.hasReachedBottom++;
+			if (this.hasReachedBottom >= 2) {
+				this.toPage("+");
+			}
 		}
 	},
 };


### PR DESCRIPTION
 ## 修复总结                                                                                                
                                                                                                             
  **问题**: 在图片放大状态下，当用户滑动到底部时，左右滑动会意外触发翻页，影响用户体验。                     
                  
  **根本原因**: 原有逻辑在触底时立即标记 `hasReachedBottom` 为 `true`，第二次触底直接翻页，没有区分用户的滑动
  方向。在放大状态下，用户可能想要左右平移查看图片，但这个操作也会被误认为是翻页意图。                       

  ## 解决方案

  ### 1. 改进触底检测逻辑
  - 将 `hasReachedBottom` 从布尔值改为计数器（0/1/2+）
  - 添加 `waitingConfirm` 状态标志，在放大状态下进入"待确认"模式

  ### 2. 添加滑动方向识别
  - 新增 `onScroll` 事件监听器，追踪 `prevScrollX` 和 `prevScrollY`
  - 计算水平和竖直滑动的距离差（deltaX 和 deltaY）

  ### 3. 区分放大和未放大状态
  - **放大状态** (`scale > 0`): 触底后进入待确认，根据后续滑动方向决定是否翻页
    - 横向滑动 > 3px：取消翻页
    - 纵向滑动 > 10px：确认翻页
  - **未放大状态**: 保持原有逻辑，第二次触底翻页

  ### 4. 其他改进
  - 在缩放、章节切换时重置滑动状态
  - 更新 `.gitignore` 忽略 `CLAUDE.md`

  ## 影响范围

  仅影响 `src/pages/photo/photo.ux` 阅读页面的触底翻页逻辑，不影响其他功能。

  ## 测试建议

  - [ ] 未放大状态下，触底翻页功能正常
  - [ ] 放大状态下，左右滑动不触发翻页
  - [ ] 放大状态下，向下滑动仍能翻页
  - [ ] 缩放和章节切换后，滑动状态正确重置